### PR TITLE
Fix lifetime issue in implementation of `Decodable` for `Cow`

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1152,7 +1152,7 @@ impl<'a, T: ?Sized> Decodable for Cow<'a, T>
     where T: ToOwned, T::Owned: Decodable
 {
     #[inline]
-    fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error> {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'a, T>, D::Error> {
         Ok(Cow::Owned(try!(Decodable::decode(d))))
     }
 }


### PR DESCRIPTION
Building the portability branch with a recent nightly compiler results in:

```
raoul@sacagawea:~/Documents/rustc-serialize/src$ cargo +nightly-2024-01-05 build
...
error[E0310]: the parameter type `T` may not live long enough
    --> src/serialize.rs:1155:5
     |
1155 |     fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |     |
     |     the parameter type `T` must be valid for the static lifetime...
     |     ...so that the type `T` will meet its required lifetime bounds...
     |
note: ...that is required by this bound
    --> /rustc/f688dd684faca5b31b156fac2c6e0ae81fc9bc90/library/alloc/src/borrow.rs:180:30
help: consider adding an explicit lifetime bound
     |
1151 | impl<'a, T: ?Sized + 'static> Decodable for Cow<'a, T>
     |                    +++++++++

For more information about this error, try `rustc --explain E0310`.
...
warning: `rustc-serialize` (lib) generated 261 warnings (85 duplicates)
error: could not compile `rustc-serialize` (lib) due to 1 previous error; 261 warnings emitted
```
(Warnings related to trait objects without an explicit dyn being deprecated and others are not fixed)
